### PR TITLE
chore(deps): All caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,29 +6,29 @@
   "homepage": "https://github.com/GitbookIO/nuts",
   "license": "Apache-2.0",
   "dependencies": {
-    "analytics-node": "6.0.0",
-    "basic-auth": "1.0.3",
+    "analytics-node": "^6.0.0",
+    "basic-auth": "^1.0.3",
     "body-parser": "^1.19.1",
-    "destroy": "1.0.3",
+    "destroy": "^1.0.3",
     "express": "^4.13.3",
-    "express-useragent": "1.0.15",
+    "express-useragent": "^1.0.15",
     "feed": "^0.3.0",
-    "github-webhook-handler": "1.0.0",
-    "lodash": "4.17.21",
-    "lru-diskcache": "1.1.1",
-    "octocat": "1.2.1",
-    "q": "1.5.1",
-    "request": "2.88.2",
-    "semver": "7.3.5",
-    "stream-res": "1.0.1",
-    "strip-bom": "2.0.0",
-    "understudy": "4.1.0",
-    "urljoin.js": "0.1.0",
-    "uuid": "8.3.2"
+    "github-webhook-handler": "^1.0.0",
+    "lodash": "^4.17.21",
+    "lru-diskcache": "^1.1.1",
+    "octocat": "^1.2.1",
+    "q": "^1.5.1",
+    "request": "^2.88.2",
+    "semver": "^7.3.5",
+    "stream-res": "^1.0.1",
+    "strip-bom": "^2.0.0",
+    "understudy": "^4.1.0",
+    "urljoin.js": "^0.1.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "mocha": "^5.2.0",
-    "should": "13.2.3"
+    "should": "^13.2.3"
   },
   "bugs": {
     "url": "https://github.com/GitbookIO/nuts/issues"


### PR DESCRIPTION
Saves on future maintenance burden, as long as maintainers don't need to release major versions:
https://github.com/npm/node-semver#caret-ranges-123-025-004