### PR TITLE
chore: Remove unused backends/github.js imports

### DIFF
--- a/lib/backends/github.js
+++ b/lib/backends/github.js
@@ -1,10 +1,8 @@
 var _ = require('lodash');
 var Q = require('q');
 var util = require('util');
-var destroy = require('destroy');
 var GitHub = require('octocat');
 var request = require('request');
-var Buffer = require('buffer').Buffer;
 var githubWebhook = require('github-webhook-handler');
 
 var Backend = require('./backend');


### PR DESCRIPTION
I see others doing things like adding a linter, but I'm too lazy at the moment to bother.